### PR TITLE
nit: Switch rule to use endswith

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Maria Vasilevskaya
 Mathew Woodyard
-
+Rick Burta

--- a/detections/risk_of_signup_fraud_by_disposable_domains.yml
+++ b/detections/risk_of_signup_fraud_by_disposable_domains.yml
@@ -5,24 +5,24 @@ description: >
     Detect potential signup fraud by monitoring the use of disposable emails.
 author: Okta
 date: 2025-07-11
-modified: 2025-08-04
+modified: 2025-08-18
 logsource:
     product: auth0
     service: signup
 detection:
     selection:
         data.type: "ss"
-        data.user_name:
-            - "*@mailinator.com"
-            - "*@yopmail.com"
-            - "*@10minutemail.com"
-            - "*@guerrillamail.com"
-            - "*@temp-mail.org"
-            - "*@disposable.com"
-            - "*@mailnesia.com"
-            - "*@sharklasers.com"
-            - "*@getnada.com"
-            - "*@mohmal.com"
+        data.user_name|endswith:
+            - "@mailinator.com"
+            - "@yopmail.com"
+            - "@10minutemail.com"
+            - "@guerrillamail.com"
+            - "@temp-mail.org"
+            - "@disposable.com"
+            - "@mailnesia.com"
+            - "@sharklasers.com"
+            - "@getnada.com"
+            - "@mohmal.com"
     condition: selection
 explanation: >
     The query monitors successful signups events within a selected time window and validates if a disposable email has been used. It alerts when the number of users with disposable emails exceeds a threshold.


### PR DESCRIPTION
### Description

This PR resolves #2 by changing rules to use `endswith` rather than `*`.

### References

https://github.com/auth0/auth0-customer-detections/issues/2

### Testing

This rule's output can be verified as the same as the previous code's output by running the following.

```
$ sigma convert \
    --target datadog \
    detections/risk_of_signup_fraud_by_disposable_domains.yml
Parsing Sigma rules  [####################################]  100%
@data.type:ss AND (@data.user_name:*@mailinator.com OR @data.user_name:*@yopmail.com OR @data.user_name:*@10minutemail.com OR @data.user_name:*@guerrillamail.com OR @data.user_name:*@temp\-mail.org OR @data.user_name:*@disposable.com OR @data.user_name:*@mailnesia.com OR @data.user_name:*@sharklasers.com OR @data.user_name:*@getnada.com OR @data.user_name:*@mohmal.com)
```

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
