### PR TITLE
Sigma rules should be valid when using multiple documents per rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
           run: pytest
 
         - name: Validate Sigma rules
-          run: sigma check detections/
+          run: sigma check --fail-on-issues detections/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: Test
 
-on:
+on:  # yamllint disable-line rule:truthy
     push:
         branches:
             - '*'

--- a/.yamllint
+++ b/.yamllint
@@ -6,7 +6,7 @@ rules:
         require-starting-space: true
         min-spaces-from-content: 1
     comments-indentation: disable
-    document-start: {present: false}
+    document-start: {present: false, ignore: [detections/, .github/workflows]}
     empty-lines: {max: 2, max-start: 2, max-end: 2}
     indentation: {spaces: 4, indent-sequences: whatever}
     line-length: disable

--- a/.yamllint
+++ b/.yamllint
@@ -13,8 +13,7 @@ rules:
         require-starting-space: true
         min-spaces-from-content: 1
     comments-indentation: disable
-    #document-start: {present: false}
-    document-start: disable
+    document-start: {present: false}
     empty-lines: {max: 2, max-start: 2, max-end: 2}
     indentation: {spaces: 4, indent-sequences: whatever}
     line-length: disable

--- a/.yamllint
+++ b/.yamllint
@@ -1,13 +1,6 @@
 # https://yamllint.readthedocs.io/en/latest/configuration.html
 extends: default
 
-ignore:
-    - .github/
-    - deprecated/
-    - other/godmode_sigma_rule.yml
-    - tests/
-    - unsupported/
-
 rules:
     comments:
         require-starting-space: true

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Each log entry is attributed with an [event type](https://auth0.com/docs/customi
 
 Okta Security recommends the use of [Log Streaming](https://auth0.com/docs/customize/log-streams) to capture events in third-party security tools in close to real-time and/or the use of [Auth0 Actions](https://auth0.com/docs/customize/actions) for security orchestration opportunities. Besides extended retention ([your Auth0 log data retention period depends on your subscription level](https://auth0.com/docs/deploy-monitor/logs/log-data-retention)), this will allow security teams to conduct a more sophisticated search and analysis of logs.
 
-Most of the detections provided in this catalogue require logs to be streamed to the third-party tools, e.g. Splunk. However, each detection is also attributed with a query in the Lucene syntax that can be used directly in the Auth0 Dashboard. This will help to locate log entries of interest, while further analysis should be conducted with the third-party tool.
+Most of the detections provided in this catalog require logs to be streamed to the third-party tools, e.g. Splunk. However, each detection is also attributed with a query in the Lucene syntax that can be used directly in the Auth0 Dashboard. This will help to locate log entries of interest, while further analysis should be conducted with the third-party tool.
 
 ## Schema and compatibility {schema}
 
-The detection rules in the `detections/` directory are compatible with the [Sigma](https://sigmahq.io/) rule specification [v2.0.0](https://github.com/SigmaHQ/sigma-specification/blob/3e27a92ca649c2798e65b4300bf58deee1149118/json-schema/sigma-detection-rule-schema.json). As a convenience for users, we have included arbirary custom fields that provide more detailed examples as an aid for users.
+The detection rules in the `detections/` directory are compatible with the [Sigma](https://sigmahq.io/) rule specification [v2.1.0](https://github.com/SigmaHQ/sigma-specification/blob/0c857d07da0e71eaaab2d667b3cce6f2c8469578/json-schema/sigma-detection-rule-schema.json). As a convenience for users, we have included arbirary custom fields that provide more detailed examples.
 
 ### Custom Fields
 

--- a/detections/credential_stuffing_signals.yml
+++ b/detections/credential_stuffing_signals.yml
@@ -104,6 +104,7 @@ tags:
     - attack.t1110.004
 ---
 title: Credential stuffing sttack risk - correlated rule # This correlation implements Signal 1 from the Splunk query above. Adjust for Signal 2 or Signal 3 if needed.
+id: eb829568-bc39-49c0-8fce-175b2a2a6d3c
 correlation:
     type: event_count
     rules:

--- a/detections/logins_or_signups_from_suspicious_ips.yml
+++ b/detections/logins_or_signups_from_suspicious_ips.yml
@@ -72,10 +72,11 @@ falsepositives:
     - The hunting window is too wide and an adversary has already moved on to other IPs and the indicated IPs belong to a legit user since then.
 level: medium
 tags:
-    - attack.credential_access
-    - attack.initial_access
+    - attack.credential-access
+    - attack.initial-access
 ---
 title: Successful logins from suspicious IPs
+id: f7694180-df6d-4d65-b733-4b9c13785f43
 correlation:
     type: value_count
     rules:

--- a/detections/many_unverified_accounts_created.yml
+++ b/detections/many_unverified_accounts_created.yml
@@ -66,10 +66,11 @@ falsepositives:
     - Legitimate users may not verify their email immediately after signup, leading to false positives.
 level: medium
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.reconnaissance
 ---
 title: Creation of many unverified accounts
+id: b15b7fbe-a53a-4675-b51b-84f604803001
 correlation:
     type: value_count
     rules:

--- a/detections/refresh_token_from_multiple_user_agent.yml
+++ b/detections/refresh_token_from_multiple_user_agent.yml
@@ -72,6 +72,7 @@ tags:
     - attack.t1078
 ---
 title: Refresh Token Exchange from Multiple User Agents - Correlation
+id: aeeaed8f-836a-4ec5-bc02-b148e7f18e20
 correlation:
     type: value_count
     rules:

--- a/detections/refresh_token_from_too_many_locations.yml
+++ b/detections/refresh_token_from_too_many_locations.yml
@@ -72,6 +72,7 @@ tags:
     - attack.t1078
 ---
 title: Refresh Token Exchange from Excessive Locations - Correlation
+id: 941ab90f-c4da-4449-8cf4-82b8a4df25b5
 correlation:
     type: value_count
     rules:

--- a/detections/refresh_token_reuse.yml
+++ b/detections/refresh_token_reuse.yml
@@ -59,6 +59,7 @@ tags:
     - attack.t1078
 ---
 title: Refresh Token Reuse Detection - Correlation
+id: a76f1e80-7208-4fe7-8aea-46cee74d1292
 correlation:
     type: event_count
     rules:

--- a/detections/risk_of_signup_fraud_by_disposable_domains.yml
+++ b/detections/risk_of_signup_fraud_by_disposable_domains.yml
@@ -66,7 +66,8 @@ tags:
     - attack.resource-development
     - attack.t1136
 ---
-title: Surge in signup events
+title: Surge in signup events from disposable domains
+id: 7b4433e7-2857-4cfc-bfe0-29dc74feb63f
 correlation:
     type: value_count
     rules:

--- a/detections/risk_of_signup_fraud_by_volume.yml
+++ b/detections/risk_of_signup_fraud_by_volume.yml
@@ -80,7 +80,8 @@ tags:
     - attack.resource-development
     - attack.t1136
 ---
-title: Surge in signup events
+title: Surge in signup events by volume
+id: 99d03061-b59a-44e5-9924-c8d5afee501c
 correlation:
     type: event_count
     rules:

--- a/test/test_yaml_should_be_valid.py
+++ b/test/test_yaml_should_be_valid.py
@@ -57,10 +57,7 @@ class TestYamlValidation:
         for yaml_file in yaml_files:
             try:
                 with open(yaml_file, "r", encoding="utf-8") as f:
-                    # Use yaml.safe_load(f) to allow only single YAML documents (no ---)
-                    # yaml.safe_load(f)
-                    # Use safe_load_all to allow for multiple YAML documents (---)
-                    list(yaml.safe_load_all(f))
+                    yaml.safe_load(f)
             except yaml.YAMLError as e:
                 pytest.fail(f"YAML syntax error in {yaml_file}: {e}")
             except Exception as e:

--- a/test/test_yaml_should_be_valid.py
+++ b/test/test_yaml_should_be_valid.py
@@ -57,7 +57,7 @@ class TestYamlValidation:
         for yaml_file in yaml_files:
             try:
                 with open(yaml_file, "r", encoding="utf-8") as f:
-                    yaml.safe_load(f)
+                    list(yaml.safe_load_all(f))
             except yaml.YAMLError as e:
                 pytest.fail(f"YAML syntax error in {yaml_file}: {e}")
             except Exception as e:


### PR DESCRIPTION
### Description

This PR aims to resolve #18 with minimal changes to rules and existing tests by:

- Always failing GitHub Actions when Sigma rules contain issues
- Updating `README.md` to reflect our continued compatibility with the latest Sigma specification version.
- Fixing invalid Sigma issues that do not validate

### References

#18
[Current Sigma project YAML rules](https://github.com/SigmaHQ/sigma/blob/ec14452cfed199586fcf8d9367b36b0afd9242aa/.yamllint)

### Testing

The tests in this PR can be validated locally following the ["Running the test suite" section of `CONTRIBUTING.md`](https://github.com/auth0/auth0-customer-detections/blob/main/CONTRIBUTING.md#running-the-test-suite).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
